### PR TITLE
Fix breaking zig change in 0.14.0; renamed std.rand.Random -> std.Random

### DIFF
--- a/src/v4.zig
+++ b/src/v4.zig
@@ -5,7 +5,7 @@ const Uuid = core.Uuid;
 const rand = std.crypto.random;
 
 /// Create a version 4 UUID using a user provided RNG
-pub fn new2(r: std.rand.Random) Uuid {
+pub fn new2(r: std.Random) Uuid {
     // Set all bits to pseudo-randomly chosen values.
     var uuid: Uuid = r.int(Uuid);
     // Set the two most significant bits of the

--- a/src/v7.zig
+++ b/src/v7.zig
@@ -14,7 +14,7 @@ const time = std.time;
 ///
 /// Implementations SHOULD utilize this UUID over
 /// version 1 and 6 if possible.
-pub fn new2(r: std.rand.Random, millis: *const fn () i64) Uuid {
+pub fn new2(r: std.Random, millis: *const fn () i64) Uuid {
     //   0                   1                   2                   3
     //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+


### PR DESCRIPTION
Caused by https://github.com/ziglang/zig/pull/18867