### PR TITLE
Use new build.zig.zon to improve cache speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ zig-cache/
 .zig-cache/
 zig-out/
 
-.vscode/**
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-zig-cache
-zig-out
+zig-cache/
+.zig-cache/
+zig-out/
+
+.vscode/**

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,9 +1,9 @@
 .{
-    .name = "uuid",
+    .name = .uuid,
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.3.0",
-
+    .fingerprint = 0xd17f50a6219ee8a0,
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.


### PR DESCRIPTION
With the new v0.14 release the `build.zig.zon` structure has changed. The new zig version does not cache dependencies with the old structure, therefore slowing down the build process (5-15 second build times).

I have updated the `build.zig.zon` file, and the `.gitignore` since it didn't include `.zig-cache/`.